### PR TITLE
Fix AGP 7 build issues

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.logger.logging_to_logcat"
+
     compileSdkVersion 31
 
     sourceSets {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest/>


### PR DESCRIPTION
Currently including v1.0.2 of this plug-in with AGP 7 will cause a build failure:

```
org.xml.sax.SAXParseException; systemId: file:/Users/vagrant/.pub-cache/hosted/pub.dev/logging_to_logcat-1.0.2/android/src/main/AndroidManifest.xml; lineNumber: 1; columnNumber: 1; Premature end of file.
```

The changes listed below resolves the build failure when using AGP 7 and should not have any issues when using AGP 8 (I'll only be able to confirm that later this week [2024/05/06]).

### Changes

* Added empty root to the Android manifest
* Added namespace to build.gradle
