### PR TITLE
Add maintainer guidelines for unused iOS sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Maintainer Guidelines
+
+The iOS plugin sources under `ios/` are intentionally unused. The `pubspec.yaml` declares only an Android plugin, making this package Android-only.
+
+Contributors should leave the iOS code untouched and **avoid adding an iOS entry** to `pubspec.yaml` unless actively developing iOS support.


### PR DESCRIPTION
## Summary
- document that the plugin is Android-only
- warn contributors not to modify the iOS folder or pubspec.yaml unless working on iOS support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cc71608b48321b7f04eea440426a3