### PR TITLE
Upgrade to Kotlin 1.9.20

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -42,5 +42,5 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.20")
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.9.20'
     repositories {
         google()
         mavenCentral()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
     plugins {
         id "com.android.application" version "8.3.0"
         id "com.android.library" version "8.3.0"
-        id "org.jetbrains.kotlin.android" version "1.9.10"
+        id "org.jetbrains.kotlin.android" version "1.9.20"
         id "dev.flutter.flutter-gradle-plugin" version "1.0.0" // adjust if needed
     }
 


### PR DESCRIPTION
## Summary
- update example project to use Kotlin 1.9.20
- bump plugin stdlib to 1.9.20

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d6c97bd6c83218973242777aaf8cb