### PR TITLE
Add setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 .idea
 /android/.idea/caches/build_file_checksums.ser
 *.iml
+flutter/
+flutter.tar.xz

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ final Logger log = Logger("MyLogger");
 log.info('demo logline!');
 ```
 
+## Development Setup
+
+Run `tool/setup.sh` to install Flutter (if necessary) and fetch this package's
+dependencies before executing tests or examples:
+
+```bash
+bash tool/setup.sh
+```
+
 ## Documentation
 Logger has a more fine-grained way of defining logging levels then Android. This plugin does the
 following mappings:

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Flutter if not already available
+if ! command -v flutter >/dev/null 2>&1; then
+  echo "Flutter not found. Installing..."
+  sudo apt-get update
+  sudo apt-get install -y curl unzip xz-utils libglu1-mesa
+  FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.19.6-stable.tar.xz"
+  curl -L "$FLUTTER_URL" -o flutter.tar.xz
+  tar xf flutter.tar.xz
+  export PATH="$PWD/flutter/bin:$PATH"
+  flutter --version
+fi
+
+# Ensure packages are fetched
+flutter pub get
+( cd example && flutter pub get )
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add a reusable `tool/setup.sh` to install Flutter and fetch dependencies
- mention the setup script in `README.md`
- ignore Flutter artifacts in `.gitignore`

## Testing
- `bash tool/setup.sh`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6846e4f414e883218879dd6cb5576f1d