### PR TITLE
Enhance setup script with Android SDK install

### DIFF
--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -10,7 +10,26 @@ if ! command -v flutter >/dev/null 2>&1; then
   curl -L "$FLUTTER_URL" -o flutter.tar.xz
   tar xf flutter.tar.xz
   export PATH="$PWD/flutter/bin:$PATH"
+  git config --global --add safe.directory "$PWD/flutter"
   flutter --version
+fi
+
+# Install Android SDK if not already available
+if ! command -v sdkmanager >/dev/null 2>&1; then
+  echo "Android SDK not found. Installing..."
+  sudo apt-get update
+  sudo apt-get install -y wget unzip openjdk-17-jdk
+  ANDROID_SDK_ROOT="$HOME/android-sdk"
+  mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+  cd "$ANDROID_SDK_ROOT"
+  CMDLINE_ZIP="commandlinetools-linux-11076708_latest.zip"
+  wget -q "https://dl.google.com/android/repository/$CMDLINE_ZIP"
+  unzip -q "$CMDLINE_ZIP" -d cmdline-tools
+  mv cmdline-tools/cmdline-tools cmdline-tools/latest
+  yes | cmdline-tools/latest/bin/sdkmanager --sdk_root="$ANDROID_SDK_ROOT" "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+  yes | cmdline-tools/latest/bin/sdkmanager --licenses >/dev/null
+  export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
+  cd -
 fi
 
 # Ensure packages are fetched


### PR DESCRIPTION
## Summary
- install Android SDK from command line tools in setup script
- mark Flutter directory as safe for git

## Testing
- `bash tool/setup.sh`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68499c7455708321bf924c54e3d6d0a0