### PR TITLE
Add namespace to example Android build

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -22,6 +22,7 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName') ?: '
 
 android {
     compileSdkVersion 34
+    namespace "com.logger.logging_to_logcat_example"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
## Summary
- add `namespace` to `android` block in example app build.gradle

## Testing
- `bash tool/setup.sh`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6849ab1fdd888321b4f363ea30740d20